### PR TITLE
feat: Implement CRD/CR viewing and management

### DIFF
--- a/common/messageTypes.ts
+++ b/common/messageTypes.ts
@@ -2,5 +2,7 @@ export const MessageTypes = {
     VIEW_READY: 'VIEW_READY',
     RUN_CMD_TERMINAL: 'RUN_CMD_TERMINAL',
     RUN_CMD_RESULT: 'RUN_CMD_RESULT',
-    SHOW_DETAILS: 'OPEN_DETAILS'
+    SHOW_DETAILS: 'OPEN_DETAILS',
+    SHOW_ERROR: 'SHOW_ERROR', // Added
+    SHOW_WARNING: 'SHOW_WARNING' // Added
 } as const;

--- a/kube-helper-view/package-lock.json
+++ b/kube-helper-view/package-lock.json
@@ -15,6 +15,7 @@
         "primevue": "^4.3.3",
         "vite-tsconfig-paths": "^5.1.4",
         "vue": "^3.5.13",
+        "vue-json-pretty": "^2.4.0",
         "vue-router": "^4.5.0",
         "vue3-ace-editor": "^2.2.4"
       },
@@ -1509,6 +1510,18 @@
         }
       }
     },
+    "node_modules/vue-json-pretty": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-2.4.0.tgz",
+      "integrity": "sha512-e9bP41DYYIc2tWaB6KuwqFJq5odZ8/GkE6vHQuGcbPn37kGk4a3n1RNw3ZYeDrl66NWXgTlOfS+M6NKkowmkWw==",
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 5.0.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.0.tgz",
@@ -2430,6 +2443,12 @@
         "@vue/server-renderer": "3.5.13",
         "@vue/shared": "3.5.13"
       }
+    },
+    "vue-json-pretty": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-2.4.0.tgz",
+      "integrity": "sha512-e9bP41DYYIc2tWaB6KuwqFJq5odZ8/GkE6vHQuGcbPn37kGk4a3n1RNw3ZYeDrl66NWXgTlOfS+M6NKkowmkWw==",
+      "requires": {}
     },
     "vue-router": {
       "version": "4.5.0",

--- a/kube-helper-view/package.json
+++ b/kube-helper-view/package.json
@@ -17,6 +17,7 @@
     "primevue": "^4.3.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vue": "^3.5.13",
+    "vue-json-pretty": "^2.4.0",
     "vue-router": "^4.5.0",
     "vue3-ace-editor": "^2.2.4"
   },

--- a/kube-helper-view/src/Router.ts
+++ b/kube-helper-view/src/Router.ts
@@ -5,6 +5,10 @@ import ClusterWideElements from "./components/clusterElements/ClusterWideElement
 import NamespaceElements from "./components/clusterElements/NamespaceElements.vue";
 import PodElement from "./components/clusterElements/PodElement.vue";
 import ContainerElement from "./components/clusterElements/ContainerElement.vue";
+import CRDList from "./components/clusterElements/elementList/CRDList.vue";
+import CRList from "./components/clusterElements/elementList/CRList.vue";
+import CRDElement from "./components/clusterElements/CRDElement.vue";
+import CRElement from "./components/clusterElements/CRElement.vue";
 import ServiceElement from "./components/clusterElements/ServiceElement.vue";
 import ConfigMapElement from "./components/clusterElements/ConfigMapElement.vue";
 import SecretElement from "./components/clusterElements/SecretElement.vue";
@@ -42,6 +46,11 @@ const routes:Readonly<RouteRecordRaw[]> = [
             {path: 'replset/:rsname', name: 'replsetoverview', component: ReplsetElement},
             {path: 'deployment/:depname', name: 'deploymentoverview', component: DeploymentElement},
             
+            // CRD and CR Routes
+            {path: 'crds', name: 'crdlist', component: CRDList},
+            {path: 'crd/:crdName/details', name: 'crddetail', component: CRDElement, props: true},
+            {path: 'crd/:crdName/resources', name: 'crlist', component: CRList, props: true},
+            {path: 'crd/:crdName/resource/:crName/:crNamespace?', name: 'crdetail', component: CRElement, props: true},
 
             {path: '', redirect: { name: 'clusteroverview' }},
         ]

--- a/kube-helper-view/src/components/clusterElements/CRDElement.vue
+++ b/kube-helper-view/src/components/clusterElements/CRDElement.vue
@@ -1,0 +1,274 @@
+<script setup lang="ts">
+import { ref, onMounted, computed, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { MessageTypes } from '@common/messageTypes';
+import { kubeCmds } from '../../constants/commands';
+import type { KubeCustomResourceDefinition } from '@apptypes/crd.type';
+import { globalStore } from '../../store/store';
+import DescribeViewer from '../common/DescribeViewer.vue';
+import EditResource from '../common/EditResource.vue'; // Assuming EditResource can handle generic resources
+
+const crd = ref<KubeCustomResourceDefinition | null>(null);
+const crdDescription = ref('');
+const loading = ref(false);
+const loadingDescription = ref(false);
+const showEditModal = ref(false);
+const route = useRoute();
+const router = useRouter();
+
+const crdName = computed(() => route.params.crdName as string);
+
+const fetchCRDDetails = () => {
+    loading.value = true;
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getSingleCRDElement', // Unique subType for this component
+        command: `${kubeCmds.getResource('crd', crdName.value)} -o json`,
+        data: { resourceName: crdName.value }
+    });
+};
+
+const fetchCRDDescription = () => {
+    loadingDescription.value = true;
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'describeCRDElement', // Unique subType
+        command: `kubectl describe crd ${crdName.value}`,
+        data: { resourceName: crdName.value }
+    });
+};
+
+window.addEventListener('message', (event) => {
+    // Assuming commandData was used in postMessage to pass resourceName
+    const { subType, data, commandData } = event.data;
+    const response = data; // data is the new response object { success, stdout, stderr, error? }
+
+    // Ensure message is for this specific CRD, using commandData if that's how resourceName was passed
+    if (commandData?.resourceName !== crdName.value) return;
+
+    if (subType === 'getSingleCRDElement') {
+        loading.value = false;
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getSingleCRDElement: ${response.stderr}`);
+            }
+            try {
+                const parsedData = JSON.parse(response.stdout) as KubeCustomResourceDefinition;
+                crd.value = parsedData;
+                updateBreadcrumb();
+            } catch (e) {
+                console.error('Error parsing CRD details:', e, response.stdout);
+                tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error parsing CRD details: ${e}` });
+                crd.value = null;
+            }
+        } else {
+            const errorMessage = response?.error || `Unknown error for getSingleCRDElement.`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error for getSingleCRDElement:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CRD details: ${errorMessage} ${errorDetails}`.trim() });
+            crd.value = null;
+        }
+    } else if (subType === 'describeCRDElement') {
+        loadingDescription.value = false;
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for describeCRDElement: ${response.stderr}`);
+                 // Potentially show stderr as a warning or append to description if it's relevant for 'describe'
+            }
+            crdDescription.value = response.stdout; // describe output is plain text
+        } else {
+            const errorMessage = response?.error || `Unknown error for describeCRDElement.`;
+            const errorDetails = response?.stderr || (response.success === false ? response.stdout : ''); // Sometimes describe errors are in stdout
+            console.error(`Error for describeCRDElement:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CRD description: ${errorMessage} ${errorDetails}`.trim() });
+            crdDescription.value = errorDetails || errorMessage; // Show error in description area
+        }
+    }
+});
+
+const storedVersions = computed(() => {
+    return crd.value?.status?.storedVersions?.join(', ') || 'N/A';
+});
+
+const acceptedNames = computed(() => {
+    if (!crd.value?.status?.acceptedNames) return [];
+    return Object.entries(crd.value.status.acceptedNames).map(([key, value]) => ({
+        key: key.charAt(0).toUpperCase() + key.slice(1), // Capitalize key
+        value: Array.isArray(value) ? value.join(', ') : value
+    }));
+});
+
+const conditions = computed(() => {
+    return crd.value?.status?.conditions || [];
+});
+
+const versions = computed(() => {
+    return crd.value?.spec?.versions || [];
+});
+
+
+const openEditModal = () => {
+    showEditModal.value = true;
+};
+
+const handleEditSuccess = () => {
+    fetchCRDDetails(); // Re-fetch details after edit
+    fetchCRDDescription();
+};
+
+const updateBreadcrumb = () => {
+    if (crd.value) {
+        const crdsEntryIndex = globalStore.breadcrumbItems.findIndex(item => item.label === 'CRDs' && item.navigateTo === 'crdlist');
+        let baseBreadcrumb = [];
+
+        if (crdsEntryIndex === -1) {
+             baseBreadcrumb = [
+                { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
+                { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 }
+            ];
+        } else {
+            baseBreadcrumb = globalStore.breadcrumbItems.slice(0, crdsEntryIndex + 1);
+        }
+
+        globalStore.setBreadcrumb([
+            ...baseBreadcrumb,
+            { label: crd.value.metadata.name, navigateTo: 'crddetail', params: { crdName: crd.value.metadata.name }, index: baseBreadcrumb.length }
+        ]);
+    }
+};
+
+
+onMounted(() => {
+    fetchCRDDetails();
+    fetchCRDDescription();
+});
+
+watch(() => route.params.crdName, (newVal, oldVal) => {
+    if (newVal && newVal !== oldVal) {
+        crd.value = null;
+        crdDescription.value = '';
+        fetchCRDDetails();
+        fetchCRDDescription();
+    }
+});
+
+</script>
+
+<template>
+    <div class="crd-element-view p-3">
+        <div v-if="loading && !crd" class="text-center">
+            <ProgressSpinner />
+            <p>Loading CRD details for {{ crdName }}...</p>
+        </div>
+        <div v-else-if="crd">
+            <div class="flex justify-content-between align-items-center mb-3">
+                <h2 class="m-0">CRD: {{ crd.metadata.name }}</h2>
+                <div>
+                    <Button icon="pi pi-pencil" label="Edit" @click="openEditModal" class="p-button-info mr-2" />
+                    <Button icon="pi pi-refresh" @click="() => { fetchCRDDetails(); fetchCRDDescription(); }" :loading="loading || loadingDescription" v-tooltip.left="'Refresh'" />
+                </div>
+            </div>
+
+            <TabView>
+                <TabPanel header="Details">
+                    <Panel header="General" class="mb-3">
+                        <div class="grid">
+                            <div class="col-12 md:col-6"><strong>Kind:</strong> {{ crd.spec.names.kind }}</div>
+                            <div class="col-12 md:col-6"><strong>Group:</strong> {{ crd.spec.group }}</div>
+                            <div class="col-12 md:col-6"><strong>Scope:</strong> {{ crd.spec.scope }}</div>
+                            <div class="col-12 md:col-6"><strong>Stored Versions:</strong> {{ storedVersions }}</div>
+                            <div class="col-12 md:col-6"><strong>UID:</strong> {{ crd.metadata.uid }}</div>
+                            <div class="col-12 md:col-6"><strong>Created:</strong> {{ new Date(crd.metadata.creationTimestamp || '').toLocaleString() }}</div>
+                        </div>
+                    </Panel>
+
+                    <Panel header="Accepted Names" class="mb-3" :toggleable="true">
+                        <DataTable :value="acceptedNames" size="small">
+                            <Column field="key" header="Name Type" />
+                            <Column field="value" header="Value" />
+                        </DataTable>
+                    </Panel>
+
+                    <Panel header="Versions" class="mb-3" :toggleable="true">
+                        <DataTable :value="versions" size="small">
+                            <Column field="name" header="Version" />
+                            <Column field="served" header="Served">
+                                <template #body="slotProps">{{ slotProps.data.served ? 'Yes' : 'No' }}</template>
+                            </Column>
+                            <Column field="storage" header="Storage">
+                                <template #body="slotProps">{{ slotProps.data.storage ? 'Yes' : 'No' }}</template>
+                            </Column>
+                            <Column field="deprecated" header="Deprecated">
+                                 <template #body="slotProps">{{ slotProps.data.deprecated ? 'Yes' : 'No' }}</template>
+                            </Column>
+                            <Column field="deprecationWarning" header="Deprecation Warning" />
+                        </DataTable>
+                    </Panel>
+
+                    <Panel header="Conditions" :toggleable="true">
+                         <DataTable :value="conditions" size="small">
+                            <Column field="type" header="Type" />
+                            <Column field="status" header="Status" />
+                            <Column field="reason" header="Reason" />
+                            <Column field="message" header="Message" />
+                            <Column field="lastTransitionTime" header="Last Transition">
+                                <template #body="slotProps">{{ new Date(slotProps.data.lastTransitionTime || '').toLocaleString() }}</template>
+                            </Column>
+                        </DataTable>
+                    </Panel>
+                </TabPanel>
+                <TabPanel header="Describe">
+                    <DescribeViewer :description="crdDescription" :loading="loadingDescription" />
+                </TabPanel>
+                 <TabPanel header="YAML">
+                    <EditResource
+                        :visible="showEditModal"
+                        resourceType="CustomResourceDefinition"
+                        :resourceName="crdName"
+                        :namespace="crd.spec.scope === 'Namespaced' ? crd.metadata.namespace : undefined"
+                        kind="CustomResourceDefinition"
+                        :resourceApiVersion="crd.apiVersion"
+                        @close="showEditModal = false"
+                        @success="handleEditSuccess"
+                    />
+                     <!-- Display read-only YAML if not editing -->
+                    <pre v-if="crd && !showEditModal" class="yaml-view">{{ JSON.stringify(crd, null, 2) }}</pre>
+                </TabPanel>
+            </TabView>
+        </div>
+        <div v-else-if="!loading">
+            <Message severity="error">Could not load details for CRD: {{ crdName }}.</Message>
+        </div>
+
+        <!-- Edit Modal will be part of the EditResource component itself if it's modal -->
+        <!-- Or use a Dialog component here if EditResource is not modal -->
+         <Dialog v-model:visible="showEditModal" modal header="Edit CRD" :style="{ width: '75vw' }">
+            <EditResource
+                :isModal="false"
+                resourceType="CustomResourceDefinition"
+                :resourceName="crdName"
+                :namespace="crd?.spec?.scope === 'Namespaced' ? crd?.metadata.namespace : undefined"
+                kind="CustomResourceDefinition"
+                :resourceApiVersion="crd?.apiVersion || 'apiextensions.k8s.io/v1'"
+                @close="showEditModal = false"
+                @success="handleEditSuccess"
+            />
+        </Dialog>
+    </div>
+</template>
+
+<style scoped>
+.crd-element-view {
+    padding: 1rem;
+}
+.yaml-view {
+    background-color: var(--surface-b);
+    color: var(--text-color);
+    padding: 1rem;
+    border-radius: 4px;
+    max-height: 600px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+</style>

--- a/kube-helper-view/src/components/clusterElements/CRElement.vue
+++ b/kube-helper-view/src/components/clusterElements/CRElement.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+import { ref, onMounted, computed, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { MessageTypes } from '@common/messageTypes';
+import { kubeCmds } from '../../constants/commands';
+import type { KubeCustomResource } from '@apptypes/cr.type';
+import type { KubeCustomResourceDefinition } from '@apptypes/crd.type'; // To get Kind
+import { globalStore } from '../../store/store';
+import DescribeViewer from '../common/DescribeViewer.vue';
+import EditResource from '../common/EditResource.vue';
+import VueJsonPretty from 'vue-json-pretty'; // For displaying spec/status
+import 'vue-json-pretty/lib/styles.css';
+
+const cr = ref<KubeCustomResource | null>(null);
+const crdKind = ref<string>(''); // To store the Kind from CRD
+const crDescription = ref('');
+const loading = ref(false);
+const loadingDescription = ref(false);
+const showEditModal = ref(false);
+const route = useRoute();
+
+const crdName = computed(() => route.params.crdName as string); // Plural name of CRD
+const crName = computed(() => route.params.crName as string);
+const crNamespace = computed(() => route.params.crNamespace as string | undefined);
+
+const fetchCRDDetailsForKind = () => {
+    // Fetch CRD to get the Kind for display and for describe command
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getSingleCRDForCRElement',
+        command: `${kubeCmds.getResource('crd', crdName.value)} -o json`,
+        data: { resourceName: crdName.value } // Pass crdName to identify response
+    });
+};
+
+const fetchCRDetails = () => {
+    if (!crd.value) { // Check if crd.value (CRD definition) is available
+        console.warn("CRD definition not yet fetched, deferring CR details fetch.");
+        // Optionally, you could re-trigger fetchCRDDetailsForKind here or show an error
+        return;
+    }
+    loading.value = true;
+    // Use plural name from the fetched CRD definition
+    let command = `kubectl get ${crd.value.spec.names.plural} ${crName.value}`;
+    if (crNamespace.value) {
+        command += ` -n ${crNamespace.value}`;
+    }
+    command += ' -o json';
+
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getSingleCRElement',
+        command: command,
+        data: { resourceName: crName.value, namespace: crNamespace.value }
+    });
+};
+
+const fetchCRDescription = () => {
+    if (!crd.value && !crdKind.value) { // Check if kind or full CRD object is available
+        console.warn("CRD Kind/Definition not yet fetched, deferring CR description fetch.");
+        return;
+    }
+    loadingDescription.value = true;
+    // Use the actual kind from CRD for describe command
+    let kindToDescribe = crdKind.value || crd.value!.spec.names.kind; // Added non-null assertion for crd.value as one of them must be true
+    let command = `kubectl describe ${kindToDescribe} ${crName.value}`;
+    if (crNamespace.value) {
+        command += ` -n ${crNamespace.value}`;
+    }
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'describeCRElement',
+        command: command,
+        data: { resourceName: crName.value, namespace: crNamespace.value }
+    });
+};
+
+
+window.addEventListener('message', (event) => {
+    const { subType, data, commandData } = event.data; // data is the new response object
+    const response = data;
+
+    if (subType === 'getSingleCRDForCRElement' && commandData?.resourceName === crdName.value) {
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getSingleCRDForCRElement: ${response.stderr}`);
+            }
+            try {
+                const crdDef = JSON.parse(response.stdout) as KubeCustomResourceDefinition;
+                crd.value = crdDef; // Store the fetched CRD definition
+                crdKind.value = crdDef.spec.names.kind;
+                fetchCRDetails();
+                fetchCRDescription();
+                updateBreadcrumb();
+            } catch (e) {
+                console.error('Error parsing CRD for Kind:', e, response.stdout);
+                tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error parsing CRD for Kind: ${e}` });
+                crd.value = null;
+                crdKind.value = '';
+            }
+        } else {
+            const errorMessage = response?.error || `Unknown error for getSingleCRDForCRElement.`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error for getSingleCRDForCRElement:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CRD for kind: ${errorMessage} ${errorDetails}`.trim() });
+            crd.value = null;
+            crdKind.value = '';
+        }
+        return; // Processed this message
+    }
+
+    // Ensure message is for this specific CR for other subtypes
+    // Using commandData for resourceName and namespace checks
+    if (commandData?.resourceName !== crName.value) return;
+    if (commandData?.namespace !== crNamespace.value && (commandData?.namespace !== undefined || crNamespace.value !== undefined)) return;
+
+
+    if (subType === 'getSingleCRElement') {
+        loading.value = false;
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getSingleCRElement: ${response.stderr}`);
+            }
+            try {
+                const parsedData = JSON.parse(response.stdout) as KubeCustomResource;
+                cr.value = parsedData;
+                if (cr.value && !cr.value.apiVersion && crd.value) {
+                     cr.value.apiVersion = `${crd.value.spec.group}/${crd.value.spec.versions.find(v => v.storage)?.name || crd.value.spec.versions[0].name}`;
+                }
+                if (cr.value && !cr.value.kind && crdKind.value) {
+                    cr.value.kind = crdKind.value;
+                }
+                updateBreadcrumb();
+            } catch (e) {
+                console.error('Error parsing CR details:', e, response.stdout);
+                tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error parsing CR details: ${e}` });
+                cr.value = null;
+            }
+        } else {
+            const errorMessage = response?.error || `Unknown error for getSingleCRElement.`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error for getSingleCRElement:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CR details: ${errorMessage} ${errorDetails}`.trim() });
+            cr.value = null;
+        }
+    } else if (subType === 'describeCRElement') {
+        loadingDescription.value = false;
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for describeCRElement: ${response.stderr}`);
+            }
+            crDescription.value = response.stdout;
+        } else {
+            const errorMessage = response?.error || `Unknown error for describeCRElement.`;
+            const errorDetails = response?.stderr || (response.success === false ? response.stdout : '');
+            console.error(`Error for describeCRElement:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CR description: ${errorMessage} ${errorDetails}`.trim() });
+            crDescription.value = errorDetails || errorMessage;
+        }
+    }
+});
+
+const openEditModal = () => {
+    showEditModal.value = true;
+};
+
+const handleEditSuccess = () => {
+    fetchCRDetails();
+    fetchCRDescription();
+};
+
+const updateBreadcrumb = () => {
+    if (cr.value && crdKind.value) {
+        const crListEntryIndex = globalStore.breadcrumbItems.findIndex(item => item.navigateTo === 'crlist' && item.params?.crdName === crdName.value);
+        let baseBreadcrumb = [];
+
+        if (crListEntryIndex === -1) { // Fallback if direct navigation
+            const crdsEntryIndex = globalStore.breadcrumbItems.findIndex(item => item.label === 'CRDs' && item.navigateTo === 'crdlist');
+            let crdsBase = [];
+            if (crdsEntryIndex === -1) {
+                 crdsBase = [
+                    { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
+                    { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 }
+                ];
+            } else {
+                crdsBase = globalStore.breadcrumbItems.slice(0, crdsEntryIndex + 1);
+            }
+            baseBreadcrumb = [
+                ...crdsBase,
+                { label: crdKind.value || crdName.value, navigateTo: 'crlist', params: { crdName: crdName.value }, index: crdsBase.length }
+            ];
+        } else {
+            baseBreadcrumb = globalStore.breadcrumbItems.slice(0, crListEntryIndex + 1);
+        }
+
+        globalStore.setBreadcrumb([
+            ...baseBreadcrumb,
+            { label: cr.value.metadata.name, navigateTo: 'crdetail', params: { crdName: crdName.value, crName: cr.value.metadata.name, crNamespace: cr.value.metadata.namespace }, index: baseBreadcrumb.length }
+        ]);
+    }
+};
+
+onMounted(() => {
+    fetchCRDDetailsForKind(); // Start by fetching CRD to get Kind
+    // fetchCRDetails and fetchCRDescription will be called after CRD details are back
+});
+
+watch(() => [route.params.crdName, route.params.crName, route.params.crNamespace], (newVal, oldVal) => {
+    if (newVal.join(',') !== oldVal.join(',')) {
+        cr.value = null;
+        crdKind.value = '';
+        crDescription.value = '';
+        fetchCRDDetailsForKind();
+    }
+});
+
+const crApiVersion = computed(() => cr.value?.apiVersion || (crd.value ? `${crd.value.spec.group}/${crd.value.spec.versions.find(v=>v.storage)?.name || crd.value.spec.versions[0].name}` : ''));
+const crActualKind = computed(() => cr.value?.kind || crdKind.value);
+
+</script>
+
+<template>
+    <div class="cr-element-view p-3">
+        <div v-if="loading && !cr" class="text-center">
+            <ProgressSpinner />
+            <p>Loading resource {{ crName }} ({{ crdKind || crdName }})...</p>
+        </div>
+        <div v-else-if="cr">
+            <div class="flex justify-content-between align-items-center mb-3">
+                <h2 class="m-0">{{ crActualKind }}: {{ cr.metadata.name }}</h2>
+                <div>
+                    <Button icon="pi pi-pencil" label="Edit" @click="openEditModal" class="p-button-info mr-2" />
+                    <Button icon="pi pi-refresh" @click="() => { fetchCRDetails(); fetchCRDescription(); }" :loading="loading || loadingDescription" v-tooltip.left="'Refresh'" />
+                </div>
+            </div>
+
+            <TabView>
+                <TabPanel header="Details">
+                    <Panel header="Metadata" class="mb-3">
+                        <div class="grid">
+                            <div class="col-12 md:col-6"><strong>Name:</strong> {{ cr.metadata.name }}</div>
+                            <div v-if="cr.metadata.namespace" class="col-12 md:col-6"><strong>Namespace:</strong> {{ cr.metadata.namespace }}</div>
+                            <div class="col-12 md:col-6"><strong>UID:</strong> {{ cr.metadata.uid }}</div>
+                            <div class="col-12 md:col-6"><strong>Created:</strong> {{ new Date(cr.metadata.creationTimestamp || '').toLocaleString() }}</div>
+                            <div class="col-12 md:col-6"><strong>Resource Version:</strong> {{ cr.metadata.resourceVersion }}</div>
+                            <div v-if="cr.metadata.generation" class="col-12 md:col-6"><strong>Generation:</strong> {{ cr.metadata.generation }}</div>
+                        </div>
+                         <template v-if="cr.metadata.labels && Object.keys(cr.metadata.labels).length > 0">
+                            <h5 class="mt-3">Labels</h5>
+                            <DataTable :value="Object.entries(cr.metadata.labels).map(([key, value]) => ({ key, value }))" size="small">
+                                <Column field="key" header="Key" />
+                                <Column field="value" header="Value" />
+                            </DataTable>
+                        </template>
+                        <template v-if="cr.metadata.annotations && Object.keys(cr.metadata.annotations).length > 0">
+                            <h5 class="mt-3">Annotations</h5>
+                            <DataTable :value="Object.entries(cr.metadata.annotations).map(([key, value]) => ({ key, value }))" size="small">
+                                <Column field="key" header="Key" />
+                                <Column field="value" header="Value" />
+                            </DataTable>
+                        </template>
+                    </Panel>
+
+                    <Panel v-if="cr.spec" header="Spec" class="mb-3" :toggleable="true">
+                        <vue-json-pretty :data="cr.spec" :deep="3" showLength />
+                    </Panel>
+
+                    <Panel v-if="cr.status" header="Status" class="mb-3" :toggleable="true">
+                        <vue-json-pretty :data="cr.status" :deep="3" showLength />
+                    </Panel>
+                </TabPanel>
+                <TabPanel header="Describe">
+                    <DescribeViewer :description="crDescription" :loading="loadingDescription" />
+                </TabPanel>
+                 <TabPanel header="YAML">
+                     <!-- Display read-only YAML if not editing -->
+                    <pre v-if="cr && !showEditModal" class="yaml-view">{{ JSON.stringify(cr, null, 2) }}</pre>
+                </TabPanel>
+            </TabView>
+        </div>
+        <div v-else-if="!loading && !crdKind">
+             <Message severity="warn">Fetching CRD information to correctly display {{ crName }}...</Message>
+        </div>
+        <div v-else-if="!loading">
+            <Message severity="error">Could not load details for {{ crdName }} {{ crName }}.</Message>
+        </div>
+
+        <Dialog v-model:visible="showEditModal" modal :header="`Edit ${crActualKind}: ${crName}`" :style="{ width: '75vw' }">
+            <EditResource
+                v-if="cr"
+                :isModal="false"
+                :resourceType="crdName"
+                :resourceName="crName"
+                :namespace="crNamespace"
+                :kind="crActualKind"
+                :resourceApiVersion="crApiVersion"
+                @close="showEditModal = false"
+                @success="handleEditSuccess"
+            />
+        </Dialog>
+    </div>
+</template>
+
+<style scoped>
+.cr-element-view {
+    padding: 1rem;
+}
+.yaml-view {
+    background-color: var(--surface-b);
+    color: var(--text-color);
+    padding: 1rem;
+    border-radius: 4px;
+    max-height: 600px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+:deep(.p-panel .p-panel-content) {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+</style>

--- a/kube-helper-view/src/components/clusterElements/ClusterWideElements.vue
+++ b/kube-helper-view/src/components/clusterElements/ClusterWideElements.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
 import Namespaces from './elementList/Namespaces.vue';
 import ClusterNodes from './elementList/ClusterNodes.vue';
 import { globalStore } from '../../store/store';
@@ -14,6 +15,12 @@ import { kubeCmds } from '@src/constants/commands';
 
 const value = ref('ns');
 const isContext = ref(false);
+
+const router = useRouter();
+
+const navigateTo = (routeName: string) => {
+    router.push({ name: routeName });
+};
 
 const getEventsCmd = kubeCmds.getNamespacedResourceByType.replace("{{resType}}", 'events');
 
@@ -48,6 +55,7 @@ onMounted(() => {
                 <Tab value="crb">Cluster Role Bindings</Tab>
                 <Tab value="sc">Storage Classes</Tab>
                 <Tab value="ic">Ingress Classes</Tab>
+                <Tab value="crd">Custom Resource Definitions</Tab>
             </TabList>
             <TabPanels>
                 <TabPanel value="ns">
@@ -77,12 +85,47 @@ onMounted(() => {
                 <TabPanel value="ic">
                     <IngressClassList />
                 </TabPanel>
+                <TabPanel value="crd">
+                    <div class="p-3 text-center">
+                        <p>View and manage Custom Resource Definitions.</p>
+                        <Button label="Go to CRDs" @click="navigateTo('crdlist')" />
+                    </div>
+                </TabPanel>
             </TabPanels>
         </Tabs>
     </div>
 </template>
 
 <style scoped>
+.cluster-over-view {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
 
+/* Ensure Tabs component itself takes full height if its parent (.cluster-over-view) is flex column */
+:deep(.p-tabs) {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
 
+:deep(.p-tabs-nav-content) {
+    flex-shrink: 0; /* Prevent nav from shrinking */
+}
+:deep(.p-tabs-panels) {
+    flex-grow: 1; /* Allow panels to take remaining height */
+    overflow-y: auto; /* Add scroll to panels if content overflows */
+    padding: 0 !important; /* Override default panel padding if components handle their own */
+    height: 100%; /* Fallback or if parent is not flex */
+}
+
+/* Ensure individual TabPanel and its direct child div take full height */
+:deep(.p-tabpanel) {
+    height: 100%;
+}
+
+:deep(.p-tabpanel > div:not(.text-center)) { /* Apply to component containers, not simple text divs */
+    height: 100%;
+}
 </style>

--- a/kube-helper-view/src/components/clusterElements/elementList/CRDList.vue
+++ b/kube-helper-view/src/components/clusterElements/elementList/CRDList.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import { MessageTypes } from '@common/messageTypes';
+import { kubeCmds } from '../../../constants/commands';
+import type { KubeCustomResourceDefinition, KubeCRDList } from '@apptypes/crd.type';
+import { globalStore } from '../../../store/store';
+import { useRouter } from 'vue-router';
+
+const crds = ref<KubeCustomResourceDefinition[]>([]);
+const loading = ref(false);
+const filterText = ref('');
+const router = useRouter();
+
+const fetchCRDs = () => {
+    loading.value = true;
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getCRDs',
+        command: kubeCmds.getCRDs,
+        data: {
+            output: 'json', // Request JSON output
+        }
+    });
+};
+
+// Listener for messages from the extension backend
+window.addEventListener('message', (event) => {
+    if (event.data.subType === 'getCRDs') { // Check subType, as type is RUN_CMD_RESULT
+        loading.value = false;
+        const response = event.data.data; // This is the { success, stdout, stderr, error? } object
+
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getCRDs: ${response.stderr}`);
+                // Optionally show a warning:
+                // tsvscode.postMessage({ type: MessageTypes.SHOW_WARNING, payload: `Warning (CRDs): ${response.stderr}` });
+            }
+            try {
+                const crdList = JSON.parse(response.stdout) as KubeCRDList;
+                crds.value = crdList.items.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+            } catch (e) {
+                console.error('Error parsing CRD list:', e, response.stdout);
+                tsvscode.postMessage({
+                    type: MessageTypes.SHOW_ERROR,
+                    payload: `Error parsing CRD list: ${e}`,
+                });
+                crds.value = [];
+            }
+        } else { // Handles response.success === false or unexpected structure
+            const errorMessage = response?.error || `Unknown error for getCRDs.`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error for getCRDs:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CRDs: ${errorMessage} ${errorDetails}`.trim() });
+            crds.value = [];
+        }
+    }
+});
+
+const filteredCRDs = computed(() => {
+    if (!filterText.value) {
+        return crds.value;
+    }
+    return crds.value.filter(crd =>
+        crd.metadata.name.toLowerCase().includes(filterText.value.toLowerCase())
+    );
+});
+
+const viewCRs = (crd: KubeCustomResourceDefinition) => {
+    // Navigate to a route that will display CRs for this CRD
+    // This route will be defined later in Router.ts
+    globalStore.setBreadcrumb([
+        { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
+        { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 }, // Assuming 'crdlist' is the route for this component
+        { label: crd.spec.names.kind, navigateTo: 'crlist', params: { crdName: crd.metadata.name }, index: 2 }
+    ]);
+    router.push({ name: 'crlist', params: { crdName: crd.metadata.name } });
+};
+
+const viewCRDDetails = (crd: KubeCustomResourceDefinition) => {
+    // Navigate to a route that will display CRD details
+    // This route will be defined later in Router.ts
+    globalStore.setBreadcrumb([
+        { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
+        { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 },
+        { label: crd.metadata.name, navigateTo: 'crddetail', params: { crdName: crd.metadata.name }, index: 2 }
+    ]);
+    router.push({ name: 'crddetail', params: { crdName: crd.metadata.name } });
+}
+
+onMounted(() => {
+    fetchCRDs();
+});
+</script>
+
+<template>
+    <div class="crd-list-view">
+        <div class="p-3">
+            <div class="flex justify-content-between align-items-center mb-3">
+                <h2 class="m-0">Custom Resource Definitions</h2>
+                <div class="flex align-items-center">
+                    <InputText v-model="filterText" placeholder="Filter CRDs" class="mr-2" />
+                    <Button icon="pi pi-refresh" @click="fetchCRDs" :loading="loading" v-tooltip.left="'Refresh'" />
+                </div>
+            </div>
+
+            <DataTable :value="filteredCRDs" :loading="loading" responsiveLayout="scroll" paginator :rows="15"
+                       :rowsPerPageOptions="[10, 15, 25, 50, 100]" stateStorage="session" stateKey="dt-crdlist-state">
+                <template #empty>No Custom Resource Definitions found.</template>
+                <template #loading>Loading CRDs...</template>
+
+                <Column field="metadata.name" header="Name" sortable>
+                    <template #body="slotProps">
+                        <a href="#" @click.prevent="viewCRDDetails(slotProps.data)">{{ slotProps.data.metadata.name }}</a>
+                    </template>
+                </Column>
+                <Column field="spec.names.kind" header="Kind" sortable />
+                <Column field="spec.group" header="Group" sortable />
+                <Column field="spec.scope" header="Scope" sortable />
+                <Column field="spec.versions[0].name" header="Default Version" sortable>
+                     <template #body="slotProps">
+                        {{ slotProps.data.spec.versions.find(v => v.storage)?.name || slotProps.data.spec.versions[0]?.name }}
+                    </template>
+                </Column>
+                 <Column header="Actions">
+                    <template #body="slotProps">
+                        <Button label="View Resources" @click="viewCRs(slotProps.data)" size="small" class="p-button-sm" />
+                    </template>
+                </Column>
+            </DataTable>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.crd-list-view {
+    padding: 1rem;
+}
+.p-datatable-emptymessage td {
+    text-align: center !important;
+    padding: 1rem;
+}
+</style>

--- a/kube-helper-view/src/components/clusterElements/elementList/CRDList.vue
+++ b/kube-helper-view/src/components/clusterElements/elementList/CRDList.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, computed } from 'vue';
 import { MessageTypes } from '@common/messageTypes';
 import { kubeCmds } from '../../../constants/commands';
-import type { KubeCustomResourceDefinition, KubeCRDList } from '@apptypes/crd.type';
+import type { KubeCustomResourceDefinition, KubeCustomResourceDefinitionVersion, KubeCRDList } from '@apptypes/crd.type';
 import { globalStore } from '../../../store/store';
 import { useRouter } from 'vue-router';
 
@@ -68,22 +68,22 @@ const filteredCRDs = computed(() => {
 const viewCRs = (crd: KubeCustomResourceDefinition) => {
     // Navigate to a route that will display CRs for this CRD
     // This route will be defined later in Router.ts
-    globalStore.setBreadcrumb([
+    globalStore.breadcrumbItems = [
         { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
         { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 }, // Assuming 'crdlist' is the route for this component
         { label: crd.spec.names.kind, navigateTo: 'crlist', params: { crdName: crd.metadata.name }, index: 2 }
-    ]);
+    ];
     router.push({ name: 'crlist', params: { crdName: crd.metadata.name } });
 };
 
 const viewCRDDetails = (crd: KubeCustomResourceDefinition) => {
     // Navigate to a route that will display CRD details
     // This route will be defined later in Router.ts
-    globalStore.setBreadcrumb([
+    globalStore.breadcrumbItems = [
         { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
         { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 },
         { label: crd.metadata.name, navigateTo: 'crddetail', params: { crdName: crd.metadata.name }, index: 2 }
-    ]);
+    ];
     router.push({ name: 'crddetail', params: { crdName: crd.metadata.name } });
 }
 
@@ -118,7 +118,7 @@ onMounted(() => {
                 <Column field="spec.scope" header="Scope" sortable />
                 <Column field="spec.versions[0].name" header="Default Version" sortable>
                      <template #body="slotProps">
-                        {{ slotProps.data.spec.versions.find(v => v.storage)?.name || slotProps.data.spec.versions[0]?.name }}
+                        {{ slotProps.data.spec.versions.find((v: KubeCustomResourceDefinitionVersion) => v.storage)?.name || slotProps.data.spec.versions[0]?.name }}
                     </template>
                 </Column>
                  <Column header="Actions">

--- a/kube-helper-view/src/components/clusterElements/elementList/CRList.vue
+++ b/kube-helper-view/src/components/clusterElements/elementList/CRList.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import { ref, onMounted, computed, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { MessageTypes } from '@common/messageTypes';
+import { kubeCmds } from '../../../constants/commands';
+import type { KubeCustomResource, KubeCRList } from '@apptypes/cr.type';
+import type { KubeCustomResourceDefinition } from '@apptypes/crd.type';
+import { globalStore } from '../../../store/store';
+import type { KubeNamespace } from '@apptypes/namespace.type'; // Assuming you have a namespace type
+
+const crs = ref<KubeCustomResource[]>([]);
+const crd = ref<KubeCustomResourceDefinition | null>(null);
+const loading = ref(false);
+const filterText = ref('');
+const route = useRoute();
+const router = useRouter();
+const selectedNamespace = ref<string | null>(globalStore.selectedNamespace || 'all'); // Default to 'all' or current
+const namespaces = ref<KubeNamespace[]>([]); // To store list of namespaces for dropdown
+
+const crdName = computed(() => route.params.crdName as string);
+
+const fetchCRDDetails = () => {
+    // Fetch the CRD details to know its scope and kind
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getSingleCRD',
+        command: `${kubeCmds.getResource('crd', crdName.value)} -o json`,
+    });
+};
+
+const fetchNamespaces = () => {
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getNamespacesForCRList',
+        command: `${kubeCmds.getNamespaces} -o json`
+    });
+};
+
+const fetchCRs = () => {
+    if (!crd.value) return;
+    loading.value = true;
+    let command = `kubectl get ${crd.value.spec.names.plural}`;
+    if (crd.value.spec.scope === 'Namespaced') {
+        if (selectedNamespace.value && selectedNamespace.value !== 'all') {
+            command += ` -n ${selectedNamespace.value}`;
+        } else {
+            command += ` -A`; // Get from all namespaces
+        }
+    }
+    command += ' -o json';
+
+    tsvscode.postMessage({
+        type: MessageTypes.RUN_CMD_RESULT,
+        subType: 'getCRs',
+        command: command,
+        data: { crdName: crdName.value } // Pass crdName to identify response
+    });
+};
+
+window.addEventListener('message', (event) => {
+    const { subType, data, command } = event.data; // data is the new response object
+    const response = data; // Rename for clarity within this block
+
+    if (subType === 'getSingleCRD') {
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getSingleCRD: ${response.stderr}`);
+            }
+            try {
+                const parsedData = JSON.parse(response.stdout) as KubeCustomResourceDefinition;
+                crd.value = parsedData;
+                if (crd.value?.spec?.scope === 'Namespaced') {
+                    fetchNamespaces(); // Fetch namespaces if CRD is namespaced
+                }
+                fetchCRs(); // Now fetch CRs
+                updateBreadcrumb();
+            } catch (e) {
+                console.error('Error parsing single CRD:', e, response.stdout);
+                tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error parsing CRD details: ${e}` });
+            }
+        } else {
+            const errorMessage = response?.error || `Unknown error for getSingleCRD.`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error for getSingleCRD:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching CRD info: ${errorMessage} ${errorDetails}`.trim() });
+        }
+    } else if (subType === 'getNamespacesForCRList') {
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getNamespacesForCRList: ${response.stderr}`);
+            }
+            try {
+                const parsedData = JSON.parse(response.stdout);
+                namespaces.value = (parsedData.items as KubeNamespace[]).sort((a,b) => a.metadata.name.localeCompare(b.metadata.name));
+            } catch (e) {
+                console.error('Error parsing namespaces:', e, response.stdout);
+                tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error parsing namespaces: ${e}` });
+                namespaces.value = [];
+            }
+        } else {
+            const errorMessage = response?.error || `Unknown error for getNamespacesForCRList.`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error for getNamespacesForCRList:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching namespaces: ${errorMessage} ${errorDetails}`.trim() });
+            namespaces.value = [];
+        }
+    } else if (subType === 'getCRs' && event.data.commandData?.crdName === crdName.value) { // commandData from original postMessage
+        loading.value = false;
+        if (response && response.success) {
+            if (response.stderr) {
+                console.warn(`Stderr content for getCRs (${crdName.value}): ${response.stderr}`);
+            }
+            try {
+                const parsedData = JSON.parse(response.stdout) as KubeCRList;
+                crs.value = (parsedData.items as KubeCustomResource[]).sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+            } catch (e) {
+                console.error('Error parsing CR list:', e, response.stdout);
+                tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error parsing resource list: ${e}` });
+                crs.value = [];
+            }
+        } else {
+            const errorMessage = response?.error || `Unknown error for getCRs (${crdName.value}).`;
+            const errorDetails = response?.stderr || '';
+            console.error(`Error fetching CRs for ${crdName.value}:`, errorMessage, errorDetails);
+            tsvscode.postMessage({ type: MessageTypes.SHOW_ERROR, payload: `Error fetching resources for ${crdName.value}: ${errorMessage} ${errorDetails}`.trim() });
+            crs.value = [];
+        }
+    }
+    // Note: The generic error handler for subType === 'error' is removed as errors are now part of the response object.
+});
+
+const filteredCRs = computed(() => {
+    if (!filterText.value) {
+        return crs.value;
+    }
+    return crs.value.filter(cr =>
+        cr.metadata.name.toLowerCase().includes(filterText.value.toLowerCase())
+    );
+});
+
+const viewCRDetails = (cr: KubeCustomResource) => {
+    if (!crd.value) return;
+    const crKind = crd.value.spec.names.kind;
+    globalStore.setBreadcrumb([
+        ...globalStore.breadcrumbItems.slice(0, globalStore.breadcrumbItems.findIndex(item => item.navigateTo === 'crlist') + 1),
+        { label: cr.metadata.name, navigateTo: 'crdetail', params: { crdName: crdName.value, crName: cr.metadata.name, crNamespace: cr.metadata.namespace }, index: globalStore.breadcrumbItems.length }
+    ]);
+    router.push({
+        name: 'crdetail',
+        params: {
+            crdName: crdName.value,
+            crName: cr.metadata.name,
+            crNamespace: cr.metadata.namespace || undefined // Pass namespace if it exists
+        }
+    });
+};
+
+const getNestedValue = (obj: any, path: string) => {
+    if (!path) return '';
+    return path.split('.').reduce((acc, part) => acc && acc[part], obj);
+};
+
+const additionalColumns = computed(() => {
+    if (!crd.value) return [];
+    // Find the stored version or fallback to the first version for printer columns
+    const version = crd.value.spec.versions.find(v => v.storage) || crd.value.spec.versions[0];
+    return version?.additionalPrinterColumns || [];
+});
+
+const updateBreadcrumb = () => {
+    if (crd.value) {
+         // Check if 'CRDs' is already in breadcrumb
+        const crdsEntryIndex = globalStore.breadcrumbItems.findIndex(item => item.label === 'CRDs' && item.navigateTo === 'crdlist');
+
+        let baseBreadcrumb = [];
+        if (crdsEntryIndex === -1) { // If 'CRDs' is not there, build from 'Cluster Overview'
+            baseBreadcrumb = [
+                { label: 'Cluster Overview', navigateTo: 'clusteroverview', params: null, index: 0 },
+                { label: 'CRDs', navigateTo: 'crdlist', params: null, index: 1 }
+            ];
+        } else { // If 'CRDs' is present, take breadcrumb up to that point
+            baseBreadcrumb = globalStore.breadcrumbItems.slice(0, crdsEntryIndex + 1);
+        }
+
+        globalStore.setBreadcrumb([
+            ...baseBreadcrumb,
+            { label: crd.value.spec.names.kind, navigateTo: 'crlist', params: { crdName: crdName.value }, index: baseBreadcrumb.length }
+        ]);
+    }
+};
+
+
+onMounted(() => {
+    fetchCRDDetails(); // Fetch CRD details first to know scope etc.
+    // fetchCRs will be called after CRD details are fetched
+});
+
+// Watch for changes in selectedNamespace and re-fetch CRs
+watch(selectedNamespace, () => {
+    if (crd.value?.spec.scope === 'Namespaced') {
+        fetchCRs();
+    }
+});
+
+// Watch for route changes if user navigates between different CRD lists
+watch(() => route.params.crdName, (newCrdName, oldCrdName) => {
+    if (newCrdName && newCrdName !== oldCrdName) {
+        crs.value = []; // Clear old data
+        crd.value = null; // Reset CRD details
+        fetchCRDDetails();
+    }
+});
+
+</script>
+
+<template>
+    <div class="cr-list-view p-3">
+        <div v-if="crd">
+            <div class="flex justify-content-between align-items-center mb-3">
+                <h2 class="m-0">{{ crd.spec.names.kind }} Resources</h2>
+                <div class="flex align-items-center">
+                    <Dropdown v-if="crd.spec.scope === 'Namespaced'"
+                              v-model="selectedNamespace"
+                              :options="[{ metadata: { name: 'all' } }, ...namespaces]"
+                              optionLabel="metadata.name"
+                              optionValue="metadata.name"
+                              placeholder="Select Namespace"
+                              class="mr-2"
+                              style="min-width: 150px;" />
+                    <InputText v-model="filterText" placeholder="Filter by name" class="mr-2" />
+                    <Button icon="pi pi-refresh" @click="fetchCRs" :loading="loading" v-tooltip.left="'Refresh'" />
+                </div>
+            </div>
+
+            <DataTable :value="filteredCRs" :loading="loading" responsiveLayout="scroll" paginator :rows="15"
+                       :rowsPerPageOptions="[10, 15, 25, 50, 100]" stateStorage="session" :stateKey="`dt-crlist-${crdName}-state`">
+                <template #empty>No resources found for {{ crd.spec.names.kind }}.</template>
+                <template #loading>Loading resources...</template>
+
+                <Column field="metadata.name" header="Name" sortable>
+                    <template #body="slotProps">
+                        <a href="#" @click.prevent="viewCRDetails(slotProps.data)">{{ slotProps.data.metadata.name }}</a>
+                    </template>
+                </Column>
+                <Column v-if="crd.spec.scope === 'Namespaced'" field="metadata.namespace" header="Namespace" sortable />
+
+                <!-- Additional Printer Columns -->
+                <Column v-for="col in additionalColumns" :key="col.name" :header="col.name"
+                        :field="col.jsonPath" :sortable="true">
+                    <template #body="slotProps">
+                        {{ getNestedValue(slotProps.data, col.jsonPath.substring(1)) }}
+                    </template>
+                </Column>
+
+                <Column field="metadata.creationTimestamp" header="Age" sortable>
+                    <template #body="slotProps">
+                        {{ new Date(slotProps.data.metadata.creationTimestamp).toLocaleString() }}
+                        <!-- Or use a timeago library -->
+                    </template>
+                </Column>
+            </DataTable>
+        </div>
+        <div v-else-if="loading">
+            <p>Loading CRD details...</p>
+        </div>
+        <div v-else>
+            <p>Could not load details for CRD: {{ crdName }}.</p>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.cr-list-view {
+    padding: 1rem;
+}
+.p-datatable-emptymessage td {
+    text-align: center !important;
+    padding: 1rem;
+}
+</style>

--- a/kube-helper-view/src/constants/commands.ts
+++ b/kube-helper-view/src/constants/commands.ts
@@ -1,18 +1,29 @@
 export const kubeCmds = {
     getClusters: "kubectl config view -o json",
-    getNonNamespacedResourceByType: "kubectl get {{resType}} {{context}} -o json",
-    describeNonNamespacedResource: "kubectl describe {{resType}} {{resName}} {{context}}",
-    // namespaced Resources
+
+    // CRDs
+    getCRDs: "kubectl get crds -o json",
+    getCRDByName: "kubectl get crd {{crdName}} -o json", // For fetching a single CRD by its full name
+    describeCRDByName: "kubectl describe crd {{crdName}}", // For describing a single CRD by its full name
+
+    // Namespaces
+    getNamespaces: "kubectl get namespaces -o json",
+
+    // Existing generic commands (might be useful for some CR operations if kind is known)
+    getNonNamespacedResourceByType: "kubectl get {{resType}} {{context}} -o json", // e.g., resType can be 'crds'
+    describeNonNamespacedResource: "kubectl describe {{resType}} {{resName}} {{context}}", // e.g., resType 'crd', resName 'my.crd.com'
+
+    // Namespaced Resources (some CRs will be namespaced)
     getNamespacedResourceByType: "kubectl get {{resType}} {{namespace}} {{context}} -o json",
-    getNamespacedResourceByName: "kubectl get {{resType}} {{resName}} {{namespace}} {{context}} -o json",
+    getNamespacedResourceByName: "kubectl get {{resType}} {{resName}} {{namespace}} {{context}} -o json", // For specific named CR
+    describeNamespacedResource: "kubectl describe {{resType}} {{resName}} {{namespace}} {{context}}", // For specific named CR
+
     getEventsPerResource: "kubectl get events --field-selector involvedObject.kind={{resType}},involvedObject.name={{resName}} {{namespace}} {{context}} -o json",
-    //
     getNamespacedResourceLogs: "kubectl logs {{resType}}/{{resName}} {{namespace}} {{context}}",
     getLogsContainer: "kubectl logs {{podname}} -c {{container}} {{namespace}} {{context}}",
-    describeNamespacedResource: "kubectl describe {{resType}} {{resName}} {{namespace}} {{context}}",
     deleteNamespacedResource: "kubectl delete {{resType}} {{resName}} {{namespace}} {{context}}",
     editNamespacedResource: "kubectl edit {{resType}} {{resName}} {{namespace}} {{context}}",
-    //
+
     execPod: "kubectl exec -it {{podname}} {{namespace}} {{context}} -- {{command}}",
     execContainer: "kubectl exec -it {{podname}} -c {{container}} {{namespace}} {{context}} -- {{command}}",
     

--- a/kube-helper-view/src/types/cluster.type.ts
+++ b/kube-helper-view/src/types/cluster.type.ts
@@ -48,3 +48,5 @@ export type KClusterConfig = {
     user: string | undefined;
     active:boolean;
 }
+export * from './crd.type';
+export * from './cr.type';

--- a/kube-helper-view/src/types/cr.type.ts
+++ b/kube-helper-view/src/types/cr.type.ts
@@ -1,0 +1,33 @@
+// Generic type for Custom Resources
+// Specific CRs will have their own spec and status structures.
+
+export interface KubeCustomResourceMetadata {
+    name: string;
+    namespace?: string;
+    uid?: string;
+    resourceVersion?: string;
+    generation?: number;
+    creationTimestamp?: string;
+    annotations?: { [key: string]: string };
+    labels?: { [key: string]: string };
+    [key: string]: any; // Allow other metadata fields
+}
+
+export interface KubeCustomResource {
+    apiVersion: string; // e.g., "group/version"
+    kind: string;
+    metadata: KubeCustomResourceMetadata;
+    spec?: { [key: string]: any }; // CR specific
+    status?: { [key: string]: any }; // CR specific
+    [key: string]: any; // Allow other top-level fields if any
+}
+
+export interface KubeCRList {
+    apiVersion: string; // e.g., "group/version"
+    kind: string; // e.g., "MyResourceList"
+    metadata: {
+        resourceVersion?: string;
+        continue?: string;
+    };
+    items: KubeCustomResource[];
+}

--- a/kube-helper-view/src/types/crd.type.ts
+++ b/kube-helper-view/src/types/crd.type.ts
@@ -1,0 +1,116 @@
+// Based on kubectl explain crd --recursive
+export interface KubeCustomResourceDefinitionCondition {
+    lastTransitionTime?: string;
+    message?: string;
+    reason?: string;
+    status: string;
+    type: string;
+}
+
+export interface KubeCustomResourceDefinitionNames {
+    categories?: string[];
+    kind: string;
+    listKind?: string;
+    plural: string;
+    shortNames?: string[];
+    singular?: string;
+}
+
+export interface KubeCustomResourceValidation {
+    openAPIV3Schema?: KubeJSONSchemaProps;
+}
+
+export interface KubeJSONSchemaProps {
+    // This is a simplified version, as a full JSON schema can be very complex.
+    // For actual validation, a more complete definition would be needed.
+    type?: string;
+    description?: string;
+    properties?: { [key: string]: KubeJSONSchemaProps };
+    items?: KubeJSONSchemaProps;
+    required?: string[];
+    format?: string;
+    // Allow any other properties for extensibility
+    [key: string]: any;
+}
+
+export interface KubeCustomResourceDefinitionVersion {
+    additionalPrinterColumns?: {
+        description?: string;
+        jsonPath: string;
+        name: string;
+        type: string;
+        format?: string;
+        priority?: number;
+    }[];
+    deprecated?: boolean;
+    deprecationWarning?: string;
+    name: string;
+    schema?: KubeCustomResourceValidation;
+    served: boolean;
+    storage: boolean;
+    subresources?: {
+        scale?: {
+            labelSelectorPath?: string;
+            specReplicasPath: string;
+            statusReplicasPath: string;
+        };
+        status?: object; // Define more specifically if needed
+    };
+}
+
+export interface KubeCustomResourceDefinitionSpec {
+    conversion?: {
+        strategy: string; // 'None' or 'Webhook'
+        webhook?: {
+            clientConfig?: {
+                caBundle?: string; // base64 encoded
+                service?: {
+                    name: string;
+                    namespace: string;
+                    path?: string;
+                    port?: number;
+                };
+                url?: string;
+            };
+            conversionReviewVersions: string[];
+        };
+    };
+    group: string;
+    names: KubeCustomResourceDefinitionNames;
+    preserveUnknownFields?: boolean;
+    scope: 'Namespaced' | 'Cluster';
+    versions: KubeCustomResourceDefinitionVersion[];
+}
+
+export interface KubeCustomResourceDefinitionStatus {
+    acceptedNames?: KubeCustomResourceDefinitionNames;
+    conditions?: KubeCustomResourceDefinitionCondition[];
+    storedVersions?: string[];
+}
+
+export interface KubeCustomResourceDefinition {
+    apiVersion: string; // Typically "apiextensions.k8s.io/v1"
+    kind: 'CustomResourceDefinition';
+    metadata: {
+        name: string;
+        uid?: string;
+        resourceVersion?: string;
+        generation?: number;
+        creationTimestamp?: string;
+        annotations?: { [key: string]: string };
+        labels?: { [key: string]: string };
+        [key: string]: any; // Allow other metadata fields
+    };
+    spec: KubeCustomResourceDefinitionSpec;
+    status?: KubeCustomResourceDefinitionStatus;
+}
+
+export interface KubeCRDList {
+    apiVersion: string; // Typically "apiextensions.k8s.io/v1"
+    kind: 'CustomResourceDefinitionList';
+    metadata: {
+        resourceVersion?: string;
+        continue?: string;
+    };
+    items: KubeCustomResourceDefinition[];
+}

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -30,15 +30,17 @@ export class SidebarUIProvider implements vscode.WebviewViewProvider {
                     break;
                 }  
                 case MessageTypes.RUN_CMD_RESULT: {
-                    runCommand(data.command).then((result) => {
+                    runCommand(data.command).then((result) => { // data is the message from webview
                         webviewView.webview.postMessage({
-                            type: data.subType,
-                            data: result
+                            type: data.subType,    // The specific subtype (e.g., "getCRDs", "getSingleCRDElement")
+                            data: result,          // The actual command execution result {success, stdout, stderr, error}
+                            commandData: data.data // Echo back the original 'data' payload from the request for context
+                                                   // This allows components to identify which request this response belongs to
+                                                   // e.g. data.data might contain { resourceName: 'foo', namespace: 'bar' }
                         });
                     });
-                    
                     break;
-                }  
+                }
                 case MessageTypes.SHOW_DETAILS: {
                     const clusterName = data.clusterName;
                     const contextName = data.contextName;

--- a/src/support/commandHandler.ts
+++ b/src/support/commandHandler.ts
@@ -7,23 +7,25 @@ import { Utils } from './utils';
 const execAsync = promisify(exec);
 export const runCommand = async (command: string) => {
     try {
+        // Execute the command. Note that execAsync throws if the command exits with a non-zero code.
         const { stdout, stderr } = await execAsync(command);
-        if (stderr) {
-            return {
-                output: stdout,
-                error: true,
-                errormessage: stderr
-            };
-        }
-        return stdout.trim();
-    } catch (error) {
         return {
-            error: true,
-            message: error
+            success: true,
+            stdout: stdout.trim(),
+            stderr: stderr.trim()
+        };
+    } catch (error: any) {
+        // error from execAsync usually has stdout and stderr properties if the command ran but failed
+        return {
+            success: false,
+            error: error.message || 'Command execution failed',
+            stdout: error.stdout ? error.stdout.trim() : '',
+            stderr: error.stderr ? error.stderr.trim() : ''
         };
     }
 };
 
+// runCommandTerminal remains unchanged, assuming it's used for different purposes (like kubectl edit)
 export const runCommandTerminal = async (command: string) => {
     try {
         const terminal = vscode.window.createTerminal({
@@ -34,7 +36,7 @@ export const runCommandTerminal = async (command: string) => {
         });
         terminal.show();
         terminal.sendText(command, true);
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to execute command: ${error}`);
+    } catch (error: any) { // Added :any type for error
+        vscode.window.showErrorMessage(`Failed to execute command: ${error.message || error}`);
     }
 };


### PR DESCRIPTION
This feature allows you to list CustomResourceDefinitions (CRDs) and their corresponding CustomResources (CRs) within the kube-helper view. You can view details, describe output, and YAML for both CRDs and CRs, and edit them.

Key changes include:

1.  **Type Definitions:**
    *   Created `crd.type.ts` and `cr.type.ts` for `KubeCustomResourceDefinition` and generic `KubeCustomResource` types.

2.  **Vue Components:**
    *   `CRDList.vue`: Fetches and displays a list of all CRDs with options to view associated resources or CRD details.
    *   `CRList.vue`: Fetches and displays CRs for a selected CRD, handling namespaced/cluster scope, namespace filtering, and dynamic columns from CRD's `additionalPrinterColumns`.
    *   `CRDElement.vue`: Displays detailed information for a CRD (metadata, spec, status, versions, conditions), `kubectl describe` output, and YAML view/edit.
    *   `CRElement.vue`: Displays detailed information for a CR (metadata, spec, status), `kubectl describe` output, and YAML view/edit. Uses `vue-json-pretty` for displaying spec/status.
    *   Added `vue-json-pretty` as a dependency for structured JSON viewing.

3.  **Routing:**
    *   Updated `Router.ts` with new routes for `crdlist`, `crddetail` (CRD details), `crlist` (list CRs for a CRD), and `crdetail` (CR details).

4.  **UI Integration:**
    *   Modified `ClusterWideElements.vue` to add a new "Custom Resource Definitions" tab, which navigates to the `crdlist` route.

5.  **Command Handling (Backend & Frontend):**
    *   Standardized the `runCommand` function in `src/support/commandHandler.ts` to return a consistent object structure: `{ success: boolean, stdout: string, stderr: string, error?: string }`.
    *   Updated all new Vue components to correctly handle this response structure, including parsing JSON from `stdout` and managing error/loading states.
    *   Corrected `kubectl get` command in `CRElement.vue` to use the CRD's plural name when fetching CR instances.
    *   Modified `src/lib/sidebar.ts` (`SidebarUIProvider`) to echo back contextual data (sent by the Vue components in their `data` payload) as `commandData` in the response message. This allows components to correctly identify which request a response belongs to.

I followed the approved plan, adapting to the existing codebase structure. You provided feedback regarding `vue-json-pretty` and the `SidebarUIProvider` changes, which have been acknowledged. Further testing and refinement would be the next logical step.